### PR TITLE
Add utils to the base images

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -47,6 +47,13 @@ COPY krb5.conf /etc/
 COPY ssmtp.conf /etc/ssmtp/
 {% endif %}
 
+RUN mkdir /opt/share
+
+{% if utils %}
+RUN mkdir /opt/share/utils
+RUN curl -sL https://github.com/ocf/utils/archive/master.tar.gz | tar -C /opt/share/utils --strip-components=1 -xzf-
+{% endif %}
+
 # Set locale
 RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
 RUN /usr/sbin/locale-gen

--- a/template.py
+++ b/template.py
@@ -39,6 +39,7 @@ DEFAULT_IMAGE_OPTIONS = {
     'ldap': True,
     'kerberos': True,
     'mail': True,
+    'utils': True,
 }
 
 IMAGES = {


### PR DESCRIPTION
We don't really have a way to share scripts otherwise between our Puppet and Docker hosts, unless we're willing to Debian package every tiny script.