### PR TITLE
Remove our jessie docker base images.

### DIFF
--- a/template.py
+++ b/template.py
@@ -46,11 +46,6 @@ DEFAULT_IMAGE_OPTIONS = {
 }
 
 IMAGES = {
-    'debian:jessie': {
-        'base': 'debian:jessie',
-        'ocf_apt_repo_dist': 'jessie',
-        'backport_dist': 'jessie-backports',
-    },
     'debian:stretch': {
         'base': 'debian:stretch',
         'ocf_apt_repo_dist': 'stretch',


### PR DESCRIPTION
Since we don't [appear to be using](https://sourcegraph.ocf.berkeley.edu/search?q=debian%5C:jessie) jessie docker images, and we're migrating completely to stretch very soon.